### PR TITLE
edge.sh fails on new installs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/baseimage:0.9.11
+FROM phusion/baseimage:0.9.16
 MAINTAINER needo <needo@superhero.org>
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -9,21 +9,23 @@ ENV HOME /root
 CMD ["/sbin/my_init"]
 
 # Fix a Debianism of the nobody's uid being 65534
-RUN usermod -u 99 nobody
-RUN usermod -g 100 nobody
+RUN usermod -u 99 nobody && \
+usermod -g 100 nobody && \
 
-RUN add-apt-repository "deb http://us.archive.ubuntu.com/ubuntu/ trusty universe multiverse"
-RUN add-apt-repository "deb http://us.archive.ubuntu.com/ubuntu/ trusty-updates universe multiverse"
-RUN apt-get update -q
+add-apt-repository "deb http://us.archive.ubuntu.com/ubuntu/ trusty universe multiverse" && \
+add-apt-repository "deb http://us.archive.ubuntu.com/ubuntu/ trusty-updates universe multiverse" && \
+apt-get update -q && \
 
 # Install Dependencies
-RUN apt-get install -qy python python-cheetah ca-certificates wget unrar
+apt-get install -qy python python-cheetah ca-certificates wget unrar unzip && \
 
 # Install SickBeard
-RUN mkdir /opt/sickbeard
-RUN wget https://github.com/midgetspy/Sick-Beard/archive/master.zip -O /tmp/sickbeard.tar.gz
-RUN tar -C /opt/sickbeard -xvf /tmp/sickbeard.tar.gz --strip-components 1
-RUN chown nobody:users /opt/sickbeard
+mkdir /opt/sickbeard && \
+cd /tmp && \
+wget https://github.com/midgetspy/Sick-Beard/archive/master.zip && \
+unzip master.zip && \
+mv Sick-Beard-master/* /opt/sickbeard/ && \
+chown nobody:users /opt/sickbeard
 
 EXPOSE 8081
 

--- a/edge.sh
+++ b/edge.sh
@@ -4,6 +4,7 @@
 if [ -z "$EDGE" ]; then
   echo "Bleeding edge not requested"
 else
+  apt-get update
   apt-get install -qy git
   rm -rf /opt/sickbeard
   git clone https://github.com/midgetspy/Sick-Beard.git /opt/sickbeard


### PR DESCRIPTION
ubuntu has updated a dependency of git (patch) and without an apt-get update in the edge.sh file it fails to install git.

also had to change the unpack routine to unzip as was getting stdin error with tar, and took the chance to condense the run statements a little and bump the baseimage to the latest at time of this pull request.
